### PR TITLE
Add README + .gitignore für Matrix Text Adventure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# IDE
+.idea/
+.vs/
+*.iml
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+
+# OS
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# 🔴 Matrix — Text Adventure (Joshua Edition)
+
+> *"Follow the white rabbit."*
+
+## 🎮 Über dieses Projekt
+
+Ein textbasiertes Adventure-Spiel im Stil der 80er/90er Jahre, inspiriert von **The Matrix** und den Anfängen der Computer- und Hackerkultur.
+
+Starte im Jahr 1999. Du bist ein talentierter Hacker, der merkwürdige Anomalien in den Systemen bemerkt. Folge dem weißen Kaninchen...
+
+## 🕹️ Features
+
+- C64-Startbildschirm mit `LOAD "*",8,1` Animation
+- Textparser mit natürlichen Befehlen (GEHE, NIMM, BENUTZE, HACKE...)
+- Mehrere Orte: Apartment, Straße, Cyber Cafe, Telefonzelle, Server-Farm
+- NPCs mit Dialogen (Cypher-Anspielung im Cafe)
+- Hacking-Minispiele (Passwort knacken, Port Scanning)
+- Alert-Level-System (zu viel Aufmerksamkeit = Game Over)
+- Verschlüsselte Nachrichten zum Dekryptieren
+- Easter Eggs und WarGames-Referenzen
+
+## 🚀 Starten
+
+```bash
+python3 Matrix_v2.0.py
+```
+
+## 📜 Befehle
+
+| Befehl | Beschreibung |
+|--------|-------------|
+| GEHE [ORT] | Bewege dich |
+| NIMM [ITEM] | Gegenstand aufheben |
+| SCHAU [OBJEKT] | Umschauen / Details |
+| BENUTZE [OBJEKT] | Interagieren |
+| HACKE [ZIEL] | Hacking-Versuch |
+| REDE MIT [NPC] | Dialog starten |
+| INVENTAR | Inventar anzeigen |
+| HILFE | Alle Befehle |
+
+## 🖤 Hommage
+
+> *Dieses Spiel ist meinem Commodore 64 gewidmet — und dem unsterblichen Gefühl, Code als Magie zu entdecken.*
+
+---
+*Designed by Oliver — DevTron*


### PR DESCRIPTION
## Änderungen

Das Repo hatte weder README noch .gitignore.

**README.md:** Spielbeschreibung, Features, Befehle, Hommage.

**Beobachtung:** 1256 Zeilen Text-Adventure mit C64-Boot-Simulation, Hacking-Minispielen, Alert-Level-System und voller Matrix-Storyline. Verdient eine ordentliche README! 🔴

**.gitignore:** Standard Python/IDE.

---
*PR by: TARSwildandfree 🤖*
*P.S.: Der Junior Dev hat gelernt: Kein Write-Access = Fork + PR. So geht Open Source!*